### PR TITLE
Repo tidy: ignore local artifacts, add env example, refresh README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Optional overrides for run_dashboard.py / Papermill
+
+# Folder that contains Archive/ and BettingPandL*.csv
+BASE_FOLDER=G:\My Drive\Betfair
+
+# Master CSV location
+MASTER_CSV=G:\My Drive\Betfair\Betfair_Master.csv
+
+# Target Google Sheet name
+GOOGLE_SHEET_NAME=Betfair Dashboard
+
+# Service account JSON path (local file)
+GOOGLE_SERVICE_ACCOUNT_JSON=.secrets/google_service_account.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,44 @@
+# -----------------------------
+# Python / build artifacts
+# -----------------------------
 __pycache__/
-*.pyc
+*.py[cod]
 *.egg-info/
 dist/
 build/
-artifacts/
-*.parquet
-*.csv
-!samples/*.csv
-.ipynb_checkpoints/
-*.json
 
-# Local secrets (never commit)
-.secrets/
-*.json
-
-# Local environment
-.env
+# -----------------------------
+# Virtual environment
+# -----------------------------
 .venv/
 
-# Papermill outputs
+# -----------------------------
+# Jupyter / Papermill
+# -----------------------------
+.ipynb_checkpoints/
 out/
 
+# -----------------------------
+# Local configuration & secrets
+# -----------------------------
+.env
+.secrets/
+
+# -----------------------------
+# Local data (real betting data)
+# -----------------------------
+data/Betfair_Master.csv
+data/Archive/
+
+# -----------------------------
+# OS / editor noise
+# -----------------------------
+.DS_Store
+Thumbs.db
+.vscode/
+
+# -----------------------------
+# Allow explicitly versioned samples (if ever added)
+# -----------------------------
+!samples/
+!samples/*.csv

--- a/README.md
+++ b/README.md
@@ -1,59 +1,17 @@
-# Betfair Dashboard
+# 📊 Betfair Dashboard (Stable)
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](
-https://colab.research.google.com/github/gazuty/betfair-dashboard/blob/colab-stable-2025-08-10/notebooks/betfair_dashboard_STABLE_2025-08-10.ipynb
-)
+This repository contains a stable notebook pipeline that processes Betfair profit/loss data
+and publishes summary tables to Google Sheets.
 
-## Project status (2025-08-10)
-
-- **Stable (default):** `colab-stable-2025-08-10`  
-  - Notebook: `notebooks/betfair_dashboard_STABLE_2025-08-10.ipynb`
-  - Known-good: updates Google Sheets with minimal write calls and a pre-push sanity check.
-- **Experimental:** `upgrade-experimental-2025-08-10`  
-  - Work in progress; breaking changes expected. Do **not** rely on it for daily updates.
+**Source of truth:** `notebooks/betfair_dashboard_STABLE.ipynb`  
+**Local runner:** `run_dashboard.py` (Papermill)
 
 ---
 
-## How to run (Colab quickstart)
+## Quickstart (Local)
 
-1. Open the stable notebook: `notebooks/betfair_dashboard_STABLE_2025-08-10.ipynb`.
-2. Set paths in **STEP 0** (BASE_FOLDER, etc.).  
-   - Place service account key at: `/content/drive/MyDrive/Betfair/<your-key>.json`  
-   - Share the target Google Sheet with that service-account email (Editor).
-3. Run **STEP 1 → STEP 7**.
-4. Run **STEP 7.5 (Sanity Check)**. It compares yesterday/today totals in `df` vs current RAW files.  
-   - If it fails, fix uploads and rerun before pushing.
-5. Run **STEP 8 (Export to Sheets)**. Uses one bulk update per sheet (avoids 429).
-
-> Tip: Daily workflow is upload new `BettingPandL*.csv` → run STEPs 1–7 → sanity check → STEP 8.
-
----
-
-## Safety
-
-- Credentials: **never** commit JSON keys. Use Drive + service account sharing only.
-- Backups: the notebook makes timestamped backups of master files before mutations.
-- Drive: keep “Version history” on; restore if needed.
-
-
-
-
-## Legacy CLI (optional)
-
-If you still use the older `bdash` CLI locally:
-
-- Install (editable):  
-  `pip install -e .`
-
-- Ingest:  
-  `bdash ingest --root "/path/to/Betfair"`
-
-- Risk:  
-  `bdash risk --master "/path/to/Betfair/master.parquet" --out "/path/to/Betfair/artifacts"`
-
-- Sheets (service account):  
-  Share your Google Sheet with the service-account email.  
-  `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json`  
-  `bdash sheets --master "/path/to/Betfair/master.parquet" --sheet-name "Betfair Dashboard"`
-
-> The CLI is considered experimental now. Daily runs should use the **stable Colab notebook** documented above.
+### 1. Create & activate a virtual environment
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt

--- a/gitignore
+++ b/gitignore
@@ -1,6 +1,0 @@
-
-*.csv
-*.xlsx
-.ipynb_checkpoints/
-data_samples/
-Archive/


### PR DESCRIPTION
Updates .gitignore to ignore local-only artifacts (env/secrets, data master, archive, papermill outputs).

Removes duplicate gitignore file.

Adds .env.example for safe configuration.

Refreshes README to reflect the stable workflow (python run_dashboard.py).